### PR TITLE
SCHED-422: Fix linear interpolation for OCS weather data and check off-by-one time slot lengths

### DIFF
--- a/env_processor.py
+++ b/env_processor.py
@@ -4,7 +4,9 @@
 import bz2
 import os
 from copy import copy
+import logging
 from tqdm import tqdm
+from typing import Optional
 
 from astropy.time import Time
 from astropy import units as u
@@ -17,17 +19,17 @@ from lucupy.sky import night_events
 from definitions import *
 
 
-def cc_band_to_float(data: str | float) -> float:
+def cc_band_to_float(data: str | float) -> Optional[float]:
     """
     Convert a CC value from a str or float to a value in the enum.
     CC values in the pandas dataset are generally 100 times the value in the CloudCover enum.
     """
-    # If it is not a number, return CCANY.
+    # If it is not a number, i.e. nan or None, return None.
     if pd.isna(data):
-        return 1.0
+        return None
 
     # If it is a str, then it might be a set. If it is a set, eval it to get the set, and return the max.
-    if type(data) == str and '{' in data:
+    if type(data) == str and "{" in data:
         return max(eval(data)) / 100
 
     # Otherwise, it is a float, so return the value divided by 100.
@@ -40,11 +42,11 @@ def process_files(site: Site, input_file_name: str, output_file_name: str) -> No
     For any missing values at the beginning or end of the night, insert ANY.
     For any missing internal values, linearly interpolate between the enum values.
     """
-    print(f'*** Processing site: {site.name} ***')
+    print(f"*** Processing site: {site.name} ***")
     # Create the time grid for the site.
     start_time = Time(first_date)
     end_time = Time(last_date)
-    time_grid = Time(np.arange(start_time.jd, end_time.jd + 1.0, (1.0 * u.day).value), format='jd')
+    time_grid = Time(np.arange(start_time.jd, end_time.jd + 1.0, (1.0 * u.day).value), format="jd")
 
     # Get all the twilights across the nights.
     _, _, _, twilight_evening_12, twilight_morning_12, _, _ = night_events(time_grid, site.location, site.timezone)
@@ -53,20 +55,27 @@ def process_files(site: Site, input_file_name: str, output_file_name: str) -> No
     time_starts = round_minute(twilight_evening_12, up=True)
     time_ends = round_minute(twilight_morning_12, up=True)
 
-    with bz2.BZ2File(input_file_name, 'rb') as input_file:
+    with bz2.BZ2File(input_file_name, "rb") as input_file:
         df = pd.read_pickle(input_file)
 
         # Add timezone information to the time_stamp_col to get between to pass.
-        df[time_stamp_col] = df[time_stamp_col].dt.tz_localize('UTC')
+        df[time_stamp_col] = df[time_stamp_col].dt.tz_localize("UTC")
 
-        # Create a row with worst values to fill in gaps.
+        # Create an empty row to fill in intermediate gaps.
         # We will have to copy and set the timestamp.
-        print(df.iloc[0])
+        # There are many rows where CC and / or IQ are nan or None. To handle these cases, we will interpolate over
+        # the data after inserting all the empty rows.
         empty_row = copy(df.iloc[0])
-        empty_row[iq_band_col] = 1.0
-        empty_row[cc_band_col] = 1.0
+        empty_row[iq_band_col] = None
+        empty_row[cc_band_col] = None
         empty_row[wind_speed_col] = 0.0
         empty_row[wind_dir_col] = 0.0
+
+        # Create a "bad" row with the worst conditions to fill in missing gaps at beginning / ends of nights or
+        # rows for entirely missing days.
+        bad_row = copy(empty_row)
+        bad_row[iq_band_col] = 1.0
+        bad_row[cc_band_col] = 1.0
 
         # Store the data by night.
         data_by_night = {}
@@ -87,18 +96,19 @@ def process_files(site: Site, input_file_name: str, output_file_name: str) -> No
             night_rows = []
 
             # Get all the rows that fall between the twilights and sort the data by timestamp.
-            night_df = df[df[time_stamp_col].between(pd_start_time,
-                                                     pd_end_time,
-                                                     inclusive='both')]
+            night_df = df[
+                df[time_stamp_col].between(pd_start_time, pd_end_time, inclusive="both")
+            ]
             night_df.sort_values(by=time_stamp_col)
 
             # SPECIAL CASE: NO INPUT FOR NIGHT.
             if night_df.empty:
                 # print(f'No data for {curr_date}... adding data.')
 
-                # Loop from pd_start_time to pd_end_time.
+                # Loop from pd_start_time to pd_end_time, inserting the worst conditions.
+                # TODO: Check to see what we should use for wind speed and direction.
                 while pd_curr_time < pd_end_time:
-                    new_row = copy(empty_row)
+                    new_row = copy(bad_row)
                     new_row[time_stamp_col] = pd_curr_time
                     night_rows.append(new_row)
                     pd_curr_time += pd_minute
@@ -118,7 +128,7 @@ def process_files(site: Site, input_file_name: str, output_file_name: str) -> No
             pd_first_time_in_frame = night_df.iloc[0][time_stamp_col]
             while pd_curr_time < pd_first_time_in_frame:
                 start_gaps += 1
-                new_row = copy(empty_row)
+                new_row = copy(bad_row)
                 new_row[time_stamp_col] = pd_curr_time
                 night_rows.append(new_row)
                 pd_curr_time += pd_minute
@@ -126,22 +136,30 @@ def process_files(site: Site, input_file_name: str, output_file_name: str) -> No
 
             # Iterate over the rows.
             for idx, curr_row in night_df.iterrows():
-                # Adjust the values in pd_row to be standardized and to eliminate nan.
+                # Adjust the values in pd_row to be standardized.
                 curr_row[cc_band_col] = cc_band_to_float(curr_row[cc_band_col])
-                curr_row[iq_band_col] = 1.0 if pd.isna(curr_row[iq_band_col]) else curr_row[iq_band_col] / 100
+                curr_row[iq_band_col] = (
+                    None
+                    if pd.isna(curr_row[iq_band_col])
+                    else curr_row[iq_band_col] / 100
+                )
+
+                # These should never happen.
                 if pd.isna(curr_row[wind_dir_col]):
+                    logging.warning(f'Site {site.name} has no wind dir entry for {curr_row[time_stamp_col]}.')
                     curr_row[wind_dir_col] = 0.0
                 if pd.isna(curr_row[wind_speed_col]):
+                    logging.warning(f'Site {site.name} has no wind speed entry for {curr_row[time_stamp_col]}.')
                     curr_row[wind_speed_col] = 0.0
 
                 # Get the timestamp for the current row and determine if there is missing data.
                 pd_next_time = curr_row[time_stamp_col]
                 gaps = int((pd_next_time - pd_curr_time).total_seconds() / 60)
 
-                # Fill in any gaps between the prev_row and the curr_row with linear interpolation.
+                # Fill in any gaps in wind data between the prev_row and the curr_row with linear interpolation.
+                # We will take another pass through the data to fill in CC and IQ entries due to the abundance
+                # of nan and None entries.
                 if gaps > 0:
-                    cc = lerp_enum(CloudCover, prev_row[cc_band_col], curr_row[cc_band_col], gaps)
-                    iq = lerp_enum(ImageQuality, prev_row[iq_band_col], curr_row[iq_band_col], gaps)
                     wind_dir = lerp_degrees(prev_row[wind_dir_col], curr_row[wind_dir_col], gaps)
                     wind_speed = lerp(prev_row[wind_speed_col], curr_row[wind_speed_col], gaps)
 
@@ -149,8 +167,6 @@ def process_files(site: Site, input_file_name: str, output_file_name: str) -> No
                     while ii < gaps:
                         new_row = copy(empty_row)
                         new_row[time_stamp_col] = pd_curr_time
-                        new_row[cc_band_col] = cc[ii]
-                        new_row[iq_band_col] = iq[ii]
                         new_row[wind_dir_col] = wind_dir[ii]
                         new_row[wind_speed_col] = wind_speed[ii]
                         night_rows.append(new_row)
@@ -158,8 +174,7 @@ def process_files(site: Site, input_file_name: str, output_file_name: str) -> No
                         pd_curr_time += pd_minute
 
                 # Add the current row and designate it to the prev_row.
-                print(curr_row)
-                print(curr_row[wind_speed_col])
+                # print(curr_row)
                 night_rows.append(curr_row)
                 prev_row = curr_row
                 pd_curr_time = curr_row[time_stamp_col] + pd_minute
@@ -167,12 +182,73 @@ def process_files(site: Site, input_file_name: str, output_file_name: str) -> No
             end_gaps = 0
             while pd_curr_time < pd_end_time:
                 end_gaps += 1
-                new_row = copy(empty_row)
+                new_row = copy(bad_row)
                 new_row[time_stamp_col] = pd_curr_time
                 night_rows.append(new_row)
                 pd_curr_time += pd_minute
 
             data_by_night[curr_date] = night_rows
+
+            # Now we make two iterations over the night rows:
+            # The first is to check for blocks of no data in the IQ column and linearly interpolate.
+            # Check the first and last row to ensure data.
+            if pd.isna(night_rows[0][iq_band_col]):
+                night_rows[0][iq_band_col] = 1.0
+            if pd.isna(night_rows[-1][iq_band_col]):
+                night_rows[-1][iq_band_col] = 1.0
+
+            prev_row = None
+            row_block = []
+            for curr_row in night_rows:
+                if prev_row is None:
+                    prev_row = curr_row
+                    continue
+
+                # If we have an na value, append to the row block for processing.
+                # Otherwise, process the row block and fill with the linear interpolation.
+                if pd.isna(curr_row[iq_band_col]):
+                    row_block.append(curr_row)
+                else:
+                    if len(row_block) > 0:
+                        # Perform the linear interpolation and fill in the values.
+                        iq_lerp = lerp_enum(ImageQuality, prev_row[iq_band_col], curr_row[iq_band_col], len(row_block))
+                        for iq_row, iq_value in zip(row_block, iq_lerp):
+                            iq_row[iq_band_col] = iq_value
+                        row_block = []
+                    prev_row = curr_row
+
+            # Repeat the same process for CC.
+            if pd.isna(night_rows[0][cc_band_col]):
+                night_rows[0][cc_band_col] = 1.0
+            if pd.isna(night_rows[-1][cc_band_col]):
+                night_rows[-1][cc_band_col] = 1.0
+
+            prev_row = None
+            row_block = []
+            for curr_row in night_rows:
+                if prev_row is None:
+                    prev_row = curr_row
+                    continue
+
+                # If we have an na value, append to the row block for processing.
+                # Otherwise, process the row block and fill with the linear interpolation.
+                if pd.isna(curr_row[cc_band_col]):
+                    row_block.append(curr_row)
+                else:
+                    if len(row_block) > 0:
+                        # Perform the linear interpolation and fill in the values.
+                        cc_lerp = lerp_enum(CloudCover, prev_row[cc_band_col], curr_row[cc_band_col], len(row_block))
+                        for cc_row, cc_value in zip(row_block, cc_lerp):
+                            cc_row[cc_band_col] = cc_value
+                        row_block = []
+                    prev_row = curr_row
+
+            # Now iterate over the night blocks and show the IQ and CC.
+            print(f'*** SITE: {site.name}, NIGHT: {curr_date} ***')
+            for curr_row in night_rows:
+                print(f'{curr_row[time_stamp_col]} -> IQ={curr_row[iq_band_col]}, CC={curr_row[cc_band_col]}')
+                assert(not pd.isna(curr_row[iq_band_col]))
+                assert(not pd.isna(curr_row[cc_band_col]))
 
         # Flatten the data back down to a table.
         flattened_data = []
@@ -181,9 +257,9 @@ def process_files(site: Site, input_file_name: str, output_file_name: str) -> No
 
         # Convert back to a pandas dataframe and store.
         modified_df = pd.DataFrame(flattened_data)
-        modified_df.to_pickle(output_file_name, compression='bz2')
+        modified_df.to_pickle(output_file_name, compression="bz2")
 
-        print('Done.')
+        print("Done.")
 
 
 def main():
@@ -191,18 +267,18 @@ def main():
         Site.GN,
         Site.GS,
     )
-    in_files = [os.path.join('data', f) for f in (
-        'gn_filtered.pickle.bz2',
-        'gs_filtered.pickle.bz2',
-    )]
-    out_files = [os.path.join('data', f) for f in (
-        'gn_weather_data.pickle.bz2',
-        'gs_weather_data.pickle.bz2',
-    )]
+    in_files = [
+        os.path.join("data", f)
+        for f in ("gn_filtered.pickle.bz2", "gs_filtered.pickle.bz2",)
+    ]
+    out_files = [
+        os.path.join("data", f)
+        for f in ("gn_weather_data.pickle.bz2", "gs_weather_data.pickle.bz2",)
+    ]
 
     for site, in_file, out_file in zip(sites, in_files, out_files):
         process_files(site, in_file, out_file)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This fixes the issue where we had wildly bouncing weather data from the original OCS env data.

Previously, we only linearly interpolated over missing rows, and for existing rows where values for CC, IQ, wind speed, and wind dir were missing, we would set the worst possible conditions.

Instead, now we add missing rows where:
* CC, IQ, wind speed, and wind dir are set to worst if at the beginning or end of night;
* no information for CC, IQ, wind speed, and wind dir if in middle of night.

Then we find blocks of missing data for each of CC, IQ, wind speed, and wind dir and linearly interpolate over them.

Note: There are still CC values that jump from 1.0 to 0.5 (or 0.5 to 1.0) but these are from the input data.

Also, a detailed investigation was done into time slot discrepancies between what was expected and what was calculated.
This appears to be a possible issue with the Scheduler and not with the scripts, and is an off-by-one where the actual data has one extra row, whereas the calculated number of time slots in the scheduler is short by one.

This may cause issues later, and will have to be addressed in the Scheduler `NightEvents` class.
Another Jira issue is being created to monitor this task.